### PR TITLE
Correção do gabarito alternativo do exercício 5 da aula 4

### DIFF
--- a/src/ocaml/Aula04/ex5.ml
+++ b/src/ocaml/Aula04/ex5.ml
@@ -28,4 +28,5 @@ let rec second_max_element_tail first second list =
 let second_max_element = function
   | [] -> failwith "empty list"
   | [x] -> failwith "list with only one element"
-  | h1 :: (h2 :: t) -> second_max_element_tail h1 h2 t
+  | h1 :: (h2 :: t) -> if h1 > h2 then second_max_element_tail h1 h2 t else second_max_element_tail h2 h1 t
+


### PR DESCRIPTION
Adicionando checagem para ordem dos argumentos passados na função auxiliar da resolução alternativa do ex5.
A resolução prévia não levava em conta o caso em que uma lista de apenas dois argumentos era fornecida como argumento. A função, como implementada nesse PR, lida com isso na chamada da função auxiliar.
Closes #1 